### PR TITLE
fix: allow base image update when check re-runs succeed

### DIFF
--- a/backend/allNonVisualChecksHavePassed.test.ts
+++ b/backend/allNonVisualChecksHavePassed.test.ts
@@ -13,15 +13,18 @@ describe('allNonVisualChecksHavePassed', () => {
               check_runs: [
                 {
                   name: 'unit tests',
-                  conclusion: 'success'
+                  conclusion: 'success',
+                  completed_at: '2023-05-02T19:11:02Z'
                 },
                 {
                   name: 'visual tests',
-                  conclusion: 'failure'
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
                 },
                 {
                   name: 'other tests',
-                  conclusion: 'success'
+                  conclusion: 'success',
+                  completed_at: '2023-05-02T19:11:02Z'
                 }
               ]
             }
@@ -42,15 +45,18 @@ describe('allNonVisualChecksHavePassed', () => {
               check_runs: [
                 {
                   name: 'unit tests',
-                  conclusion: 'success'
+                  conclusion: 'success',
+                  completed_at: '2023-05-02T19:11:02Z'
                 },
                 {
                   name: 'visual tests',
-                  conclusion: 'failure'
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
                 },
                 {
                   name: 'other tests',
-                  conclusion: 'failure'
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
                 }
               ]
             }
@@ -71,15 +77,18 @@ describe('allNonVisualChecksHavePassed', () => {
               check_runs: [
                 {
                   name: 'unit tests',
-                  conclusion: 'success'
+                  conclusion: 'success',
+                  completed_at: '2023-05-02T19:11:02Z'
                 },
                 {
                   name: 'visual tests',
-                  conclusion: 'failure'
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
                 },
                 {
                   name: 'other tests',
-                  conclusion: 'skipped'
+                  conclusion: 'skipped',
+                  completed_at: '2023-05-02T19:11:02Z'
                 }
               ]
             }
@@ -89,5 +98,79 @@ describe('allNonVisualChecksHavePassed', () => {
     }));
     const result = await allNonVisualChecksHavePassed('github-owner', 'github-repo', 'sha');
     expect(result).toBe(true);
+  });
+
+  it('should return true when a non-visual check failed on an early run but passed on the latest run', async () => {
+    (getOctokit as jest.Mock).mockImplementation(() => ({
+      rest: {
+        checks: {
+          listForRef: jest.fn().mockReturnValue({
+            data: {
+              check_runs: [
+                {
+                  name: 'unit tests',
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:10:02Z'
+                },
+                {
+                  name: 'unit tests',
+                  conclusion: 'success',
+                  completed_at: '2023-05-02T19:11:02Z'
+                },
+                {
+                  name: 'visual tests',
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
+                },
+                {
+                  name: 'other tests',
+                  conclusion: 'skipped',
+                  completed_at: '2023-05-02T19:11:02Z'
+                }
+              ]
+            }
+          })
+        }
+      }
+    }));
+    const result = await allNonVisualChecksHavePassed('github-owner', 'github-repo', 'sha');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when a non-visual check fails on multiple runs and never passed', async () => {
+    (getOctokit as jest.Mock).mockImplementation(() => ({
+      rest: {
+        checks: {
+          listForRef: jest.fn().mockReturnValue({
+            data: {
+              check_runs: [
+                {
+                  name: 'unit tests',
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
+                },
+                {
+                  name: 'unit tests',
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:10:02Z'
+                },
+                {
+                  name: 'visual tests',
+                  conclusion: 'failure',
+                  completed_at: '2023-05-02T19:11:02Z'
+                },
+                {
+                  name: 'other tests',
+                  conclusion: 'skipped',
+                  completed_at: '2023-05-02T19:11:02Z'
+                }
+              ]
+            }
+          })
+        }
+      }
+    }));
+    const result = await allNonVisualChecksHavePassed('github-owner', 'github-repo', 'sha');
+    expect(result).toBe(false);
   });
 });

--- a/backend/allNonVisualChecksHavePassed.ts
+++ b/backend/allNonVisualChecksHavePassed.ts
@@ -18,9 +18,9 @@ export const allNonVisualChecksHavePassed = async (owner: string, repo: string, 
   });
   const nonVisualChecks = data.check_runs.filter(({ name }) => !isVisualTest(name));
   const groupedChecks = groupBy(nonVisualChecks, 'name');
-  const mostRecentCheckByName = nonVisualChecks.filter(check => {
+  const mostRecentChecks = nonVisualChecks.filter(check => {
     const checksSortedByDescTime = sortBy(groupedChecks[check.name], 'completed_at').reverse();
     return isEqual(check, checksSortedByDescTime[0]);
   });
-  return mostRecentCheckByName.every(({ conclusion }) => allowedConclusions.includes(conclusion));
+  return mostRecentChecks.every(({ conclusion }) => allowedConclusions.includes(conclusion));
 };

--- a/backend/allNonVisualChecksHavePassed.ts
+++ b/backend/allNonVisualChecksHavePassed.ts
@@ -1,5 +1,6 @@
 import { getOctokit } from './getOctokit';
 import { RestEndpointMethodTypes } from '@octokit/rest';
+import { groupBy, isEqual, sortBy } from 'lodash';
 
 type CheckRunConclusion = RestEndpointMethodTypes['checks']['listForRef']['response']['data']['check_runs'][number]['conclusion'];
 
@@ -15,5 +16,11 @@ export const allNonVisualChecksHavePassed = async (owner: string, repo: string, 
     repo,
     ref: sha
   });
-  return data.check_runs.filter(({ name }) => !isVisualTest(name)).every(checkRun => allowedConclusions.includes(checkRun.conclusion));
+  const nonVisualChecks = data.check_runs.filter(({ name }) => !isVisualTest(name));
+  const groupedChecks = groupBy(nonVisualChecks, 'name');
+  const mostRecentCheckByName = nonVisualChecks.filter(check => {
+    const checksSortedByDescTime = sortBy(groupedChecks[check.name], 'completed_at').reverse();
+    return isEqual(check, checksSortedByDescTime[0]);
+  });
+  return mostRecentCheckByName.every(({ conclusion }) => allowedConclusions.includes(conclusion));
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Fixes an issue where a PR with a re-ran check is wrongly unable to update base images.
