### PR TITLE
fix: use commit statuses for base image update check

### DIFF
--- a/app/backend/test/allNonVisualChecksHavePassed.test.ts
+++ b/app/backend/test/allNonVisualChecksHavePassed.test.ts
@@ -196,11 +196,6 @@ describe('allNonVisualChecksHavePassed', () => {
                 state: 'failure',
                 created_at: '2023-05-02T19:11:02Z',
               },
-              {
-                context: 'other tests',
-                state: 'skipped',
-                created_at: '2023-05-02T19:11:02Z',
-              },
             ],
           }),
         },

--- a/app/backend/test/allNonVisualChecksHavePassed.test.ts
+++ b/app/backend/test/allNonVisualChecksHavePassed.test.ts
@@ -8,27 +8,25 @@ describe('allNonVisualChecksHavePassed', () => {
   it('should return true when all non-visual pr checks pass', async () => {
     (getOctokit as jest.Mock).mockImplementation(() => ({
       rest: {
-        checks: {
-          listForRef: jest.fn().mockReturnValue({
-            data: {
-              check_runs: [
-                {
-                  name: 'unit tests',
-                  conclusion: 'success',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: VISUAL_REGRESSION_CONTEXT,
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'other tests',
-                  conclusion: 'success',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-              ],
-            },
+        repos: {
+          listCommitStatusesForRef: jest.fn().mockReturnValue({
+            data: [
+              {
+                context: 'unit tests',
+                state: 'success',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: VISUAL_REGRESSION_CONTEXT,
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: 'other tests',
+                state: 'success',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+            ],
           }),
         },
       },
@@ -44,27 +42,25 @@ describe('allNonVisualChecksHavePassed', () => {
   it('should return false when at least one visual test job failed', async () => {
     (getOctokit as jest.Mock).mockImplementation(() => ({
       rest: {
-        checks: {
-          listForRef: jest.fn().mockReturnValue({
-            data: {
-              check_runs: [
-                {
-                  name: 'unit tests',
-                  conclusion: 'success',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: VISUAL_REGRESSION_CONTEXT,
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'visual tests',
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-              ],
-            },
+        repos: {
+          listCommitStatusesForRef: jest.fn().mockReturnValue({
+            data: [
+              {
+                context: 'unit tests',
+                state: 'success',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: VISUAL_REGRESSION_CONTEXT,
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: 'visual tests',
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+            ],
           }),
         },
       },
@@ -80,27 +76,25 @@ describe('allNonVisualChecksHavePassed', () => {
   it('should return false when at least one non-visual check failed', async () => {
     (getOctokit as jest.Mock).mockImplementation(() => ({
       rest: {
-        checks: {
-          listForRef: jest.fn().mockReturnValue({
-            data: {
-              check_runs: [
-                {
-                  name: 'unit tests',
-                  conclusion: 'success',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: VISUAL_REGRESSION_CONTEXT,
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'other tests',
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-              ],
-            },
+        repos: {
+          listCommitStatusesForRef: jest.fn().mockReturnValue({
+            data: [
+              {
+                context: 'unit tests',
+                state: 'success',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: VISUAL_REGRESSION_CONTEXT,
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: 'other tests',
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+            ],
           }),
         },
       },
@@ -113,30 +107,28 @@ describe('allNonVisualChecksHavePassed', () => {
     expect(result).toBe(false);
   });
 
-  it('should return true when all non-visual pr checks pass but some are skipped', async () => {
+  it('should return false when all non-visual pr checks pass but some are pending', async () => {
     (getOctokit as jest.Mock).mockImplementation(() => ({
       rest: {
-        checks: {
-          listForRef: jest.fn().mockReturnValue({
-            data: {
-              check_runs: [
-                {
-                  name: 'unit tests',
-                  conclusion: 'success',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: VISUAL_REGRESSION_CONTEXT,
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'other tests',
-                  conclusion: 'skipped',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-              ],
-            },
+        repos: {
+          listCommitStatusesForRef: jest.fn().mockReturnValue({
+            data: [
+              {
+                context: 'unit tests',
+                state: 'success',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: VISUAL_REGRESSION_CONTEXT,
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: 'other tests',
+                state: 'pending',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+            ],
           }),
         },
       },
@@ -146,38 +138,31 @@ describe('allNonVisualChecksHavePassed', () => {
       'github-repo',
       'sha'
     );
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it('should return true when a non-visual check failed on an early run but passed on the latest run', async () => {
     (getOctokit as jest.Mock).mockImplementation(() => ({
       rest: {
-        checks: {
-          listForRef: jest.fn().mockReturnValue({
-            data: {
-              check_runs: [
-                {
-                  name: 'unit tests',
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:10:02Z',
-                },
-                {
-                  name: 'unit tests',
-                  conclusion: 'success',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: VISUAL_REGRESSION_CONTEXT,
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'other tests',
-                  conclusion: 'skipped',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-              ],
-            },
+        repos: {
+          listCommitStatusesForRef: jest.fn().mockReturnValue({
+            data: [
+              {
+                context: 'unit tests',
+                state: 'failure',
+                created_at: '2023-05-02T19:10:02Z',
+              },
+              {
+                context: 'unit tests',
+                state: 'success',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: VISUAL_REGRESSION_CONTEXT,
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+            ],
           }),
         },
       },
@@ -193,32 +178,30 @@ describe('allNonVisualChecksHavePassed', () => {
   it('should return false when a non-visual check fails on multiple runs and never passed', async () => {
     (getOctokit as jest.Mock).mockImplementation(() => ({
       rest: {
-        checks: {
-          listForRef: jest.fn().mockReturnValue({
-            data: {
-              check_runs: [
-                {
-                  name: 'unit tests',
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'unit tests',
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:10:02Z',
-                },
-                {
-                  name: VISUAL_REGRESSION_CONTEXT,
-                  conclusion: 'failure',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-                {
-                  name: 'other tests',
-                  conclusion: 'skipped',
-                  completed_at: '2023-05-02T19:11:02Z',
-                },
-              ],
-            },
+        repos: {
+          listCommitStatusesForRef: jest.fn().mockReturnValue({
+            data: [
+              {
+                context: 'unit tests',
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: 'unit tests',
+                state: 'failure',
+                created_at: '2023-05-02T19:10:02Z',
+              },
+              {
+                context: VISUAL_REGRESSION_CONTEXT,
+                state: 'failure',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+              {
+                context: 'other tests',
+                state: 'skipped',
+                created_at: '2023-05-02T19:11:02Z',
+              },
+            ],
           }),
         },
       },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Use commit statuses instead of the checks API to determine if base image update should be allowed. This should make it more flexible for clients.
