### PR TITLE
fix(comparadise-utils): enforce rawName argument when test file contains multiple tests

### DIFF
--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -28,6 +28,11 @@ function getTestFolderPathFromScripts(rawName?: string) {
     );
   }
 
+  const currentTestNumber = Cypress.mocha.getRunner().currentRunnable?.order
+  if (!rawName && typeof currentTestNumber === 'number' && currentTestNumber > 1) {
+    throw new Error('❌ The rawName argument was not provided to matchScreenshot and is required for test files containing multiple tests!')
+  }
+
   const testName = relativeTestPath.substring(
     relativeTestPath.lastIndexOf('/') + 1,
     relativeTestPath.lastIndexOf(SUFFIX_TEST_IDENTIFIER)
@@ -118,3 +123,19 @@ Cypress.Commands.add(
   { prevSubject: ['optional', 'element', 'window', 'document'] },
   matchScreenshot
 );
+
+interface ExtendedCurrentRunnable extends Mocha.Runnable {
+  currentRunnable?: {
+    order?: unknown;
+  }
+}
+
+declare global {
+  namespace Cypress {
+    interface Cypress {
+      mocha: {
+        getRunner: () => ExtendedCurrentRunnable;
+      };
+    }
+  }
+}

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -28,9 +28,15 @@ function getTestFolderPathFromScripts(rawName?: string) {
     );
   }
 
-  const currentTestNumber = Cypress.mocha.getRunner().currentRunnable?.order
-  if (!rawName && typeof currentTestNumber === 'number' && currentTestNumber > 1) {
-    throw new Error('❌ The rawName argument was not provided to matchScreenshot and is required for test files containing multiple tests!')
+  const currentTestNumber = Cypress.mocha.getRunner().currentRunnable?.order;
+  if (
+    !rawName &&
+    typeof currentTestNumber === 'number' &&
+    currentTestNumber > 1
+  ) {
+    throw new Error(
+      '❌ The rawName argument was not provided to matchScreenshot and is required for test files containing multiple tests!'
+    );
   }
 
   const testName = relativeTestPath.substring(
@@ -127,7 +133,7 @@ Cypress.Commands.add(
 interface ExtendedCurrentRunnable extends Mocha.Runnable {
   currentRunnable?: {
     order?: unknown;
-  }
+  };
 }
 
 declare global {

--- a/docs/docs/setup/writing-visual-tests.md
+++ b/docs/docs/setup/writing-visual-tests.md
@@ -70,7 +70,7 @@ describe('MyComponent visual test', () => {
 
 By default, `matchScreenshot` will infer the name of your test from the name of your file and create a folder to save the base, new, and diff images to.
 
-However, if you have multiple visual tests in a single file, you should pass a different `rawName` for each test to vary the paths where screenshots will be saved.
+However, if you have multiple visual tests in a single file, you are required to provide a different `rawName` for each test to vary the paths where screenshots will be saved.
 
 #### options - optional (Cypress.ScreenshotOptions)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
When the `rawName` argument is not provided, `matchScreenshot()` will generate a screenshot file name by default using the relative path to the test file. However, when multiple tests exist in the same file and neither one provides `rawName`, these file names are not unique and each new screenshot will be overwritten by the last.

This PR
- Fixes this issue
- Updates the [documentation](https://opensource.expediagroup.com/comparadise/docs/setup/writing-visual-tests) accordingly
