### PR TITLE
fix(app): default to diff in single image view

### DIFF
--- a/app/frontend/components/main-page.tsx
+++ b/app/frontend/components/main-page.tsx
@@ -16,7 +16,7 @@ import { ArrowBackIcon, ArrowForwardIcon } from './arrows';
 
 export const MainPage = () => {
   const [viewType, setViewType] = React.useState<ImageView | undefined>();
-  const [singleImageViewIndex, setSingleImageViewIndex] = React.useState(0);
+  const [singleImageViewIndex, setSingleImageViewIndex] = React.useState(1);
 
   const [searchParams] = useSearchParams();
   const params: Record<string, string | undefined> = Object.fromEntries(

--- a/app/frontend/cypress/component/App.cy.tsx
+++ b/app/frontend/cypress/component/App.cy.tsx
@@ -52,9 +52,9 @@ describe('App', () => {
       );
     });
 
-    it('should default to the base image view of the first spec in the response list', () => {
+    it('should default to the diff image view of the first spec in the response list', () => {
       cy.findByRole('heading', { name: 'large/example' });
-      cy.findByAltText('base');
+      cy.findByAltText('diff');
       cy.findByRole('button', { name: /back-arrow/ }).should('be.disabled');
     });
 
@@ -70,13 +70,13 @@ describe('App', () => {
       cy.findByAltText('new');
     });
 
-    it('should switch between specs and default to base image for each one', () => {
+    it('should switch between specs and default to diff image for each one', () => {
       cy.findByRole('button', { name: /forward-arrow/ }).click();
       cy.findByRole('heading', { name: 'small/example' });
-      cy.findByAltText('base');
+      cy.findByAltText('diff');
       cy.findByRole('button', { name: /back-arrow/ }).click();
       cy.findByRole('heading', { name: 'large/example' });
-      cy.findByAltText('base');
+      cy.findByAltText('diff');
       cy.findByRole('button', { name: /side-by-side/i }).should('be.disabled');
     });
 
@@ -218,12 +218,12 @@ describe('App', () => {
       );
     });
 
-    it('should default to base when no new image was found and the currently selected image is new', () => {
+    it('should default to diff when no new image was found and the currently selected image is new', () => {
       cy.findByRole('heading', { name: 'large/example' });
       cy.findByRole('button', { name: /new/ }).click();
       cy.findByAltText('new');
       cy.findByRole('button', { name: /forward-arrow/ }).click();
-      cy.findByAltText('base');
+      cy.findByAltText('diff');
     });
   });
 });

--- a/app/frontend/cypress/component/App.cy.tsx
+++ b/app/frontend/cypress/component/App.cy.tsx
@@ -99,8 +99,8 @@ describe('App', () => {
       cy.findByAltText('diff');
       cy.findByAltText('new');
       cy.findByRole('button', { name: /single/i }).click();
-      cy.findByAltText('base');
-      cy.findByAltText('diff').should('not.exist');
+      cy.findByAltText('diff');
+      cy.findByAltText('base').should('not.exist');
       cy.findByAltText('new').should('not.exist');
       cy.findByRole('button', { name: /side-by-side/i }).should('be.enabled');
     });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Default to the "diff" image when in single view. Makes more sense as a default than "base"
