### PR TITLE
refactor(app): use file names to manage state rather than indices

### DIFF
--- a/action/tsconfig.json
+++ b/action/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["./**/*"]
+  "include": ["./**/*", "../reset.d.ts"]
 }

--- a/app/backend/src/getOctokit.ts
+++ b/app/backend/src/getOctokit.ts
@@ -21,11 +21,10 @@ export const getOctokit = (owner: string, repo: string) => {
   }
   const repoSecrets = result.data[`${owner}/${repo}`];
   const { githubToken, githubApiUrl } = repoSecrets ?? {};
-  if (!githubToken || !githubApiUrl) {
+  if (!githubToken) {
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message:
-        'Failed to parse secrets.json: missing githubToken or githubApiUrl'
+      message: `Missing githubToken for repo ${owner}/${repo}`
     });
   }
   return new Octokit({

--- a/app/backend/src/getOctokit.ts
+++ b/app/backend/src/getOctokit.ts
@@ -8,7 +8,7 @@ export const getOctokit = (owner: string, repo: string) => {
   if (!existsSync(secretsFilePath)) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
-      message: `No GitHub configs were found for ${owner}/${repo}`
+      message: 'Missing secrets.json file'
     });
   }
   const parsedJson = JSON.parse(readFileSync(secretsFilePath).toString());
@@ -23,7 +23,7 @@ export const getOctokit = (owner: string, repo: string) => {
   const { githubToken, githubApiUrl } = repoSecrets ?? {};
   if (!githubToken) {
     throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
+      code: 'UNAUTHORIZED',
       message: `Missing githubToken for repo ${owner}/${repo}`
     });
   }

--- a/app/backend/src/getOctokit.ts
+++ b/app/backend/src/getOctokit.ts
@@ -1,20 +1,35 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { TRPCError } from '@trpc/server';
 import { Octokit } from '@octokit/rest';
+import { secretsJsonSchema } from './schema';
 
 export const getOctokit = (owner: string, repo: string) => {
-  try {
-    const {
-      [`${owner}/${repo}`]: { githubToken, githubApiUrl }
-    } = JSON.parse(readFileSync(`/vault/secrets/secrets.json`).toString());
-    return new Octokit({
-      auth: githubToken,
-      baseUrl: githubApiUrl
-    });
-  } catch (error) {
+  const secretsFilePath = '/vault/secrets/secrets.json';
+  if (!existsSync(secretsFilePath)) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
-      message: `No GitHub configs were found for ${owner}/${repo}: ${error}`
+      message: `No GitHub configs were found for ${owner}/${repo}`
     });
   }
+  const parsedJson = JSON.parse(readFileSync(secretsFilePath).toString());
+  const result = secretsJsonSchema.safeParse(parsedJson);
+  if (!result.success) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `Failed to parse secrets.json: ${result.error}`
+    });
+  }
+  const repoSecrets = result.data[`${owner}/${repo}`];
+  const { githubToken, githubApiUrl } = repoSecrets ?? {};
+  if (!githubToken || !githubApiUrl) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message:
+        'Failed to parse secrets.json: missing githubToken or githubApiUrl'
+    });
+  }
+  return new Octokit({
+    auth: githubToken,
+    baseUrl: githubApiUrl
+  });
 };

--- a/app/backend/src/schema.ts
+++ b/app/backend/src/schema.ts
@@ -21,3 +21,14 @@ export type UpdateBaseImagesInput = z.infer<typeof updateBaseImagesInputSchema>;
 export type UpdateCommitStatusInput = z.infer<
   typeof updateCommitStatusInputSchema
 >;
+export const FILE_NAMES = {
+  BASE: 'base',
+  DIFF: 'diff',
+  NEW: 'new'
+} as const;
+export const fileNameSchema = z.enum([
+  FILE_NAMES.BASE,
+  FILE_NAMES.DIFF,
+  FILE_NAMES.NEW
+]);
+export type FileName = z.infer<typeof fileNameSchema>;

--- a/app/backend/src/schema.ts
+++ b/app/backend/src/schema.ts
@@ -11,16 +11,15 @@ export const updateBaseImagesInputSchema = z.object({
   repo: z.string().min(1),
   owner: z.string().min(1)
 });
-export const updateCommitStatusInputSchema = z.object({
-  hash: z.string().min(1),
-  repo: z.string().min(1),
-  owner: z.string().min(1)
-});
+export const secretsJsonSchema = z.record(
+  z.string(),
+  z.object({
+    githubToken: z.string(),
+    githubApiUrl: z.string()
+  })
+);
 export type FetchCurrentPageInput = z.infer<typeof fetchCurrentPageInputSchema>;
 export type UpdateBaseImagesInput = z.infer<typeof updateBaseImagesInputSchema>;
-export type UpdateCommitStatusInput = z.infer<
-  typeof updateCommitStatusInputSchema
->;
 export const FILE_NAMES = {
   BASE: 'base',
   DIFF: 'diff',
@@ -31,4 +30,3 @@ export const fileNameSchema = z.enum([
   FILE_NAMES.DIFF,
   FILE_NAMES.NEW
 ]);
-export type FileName = z.infer<typeof fileNameSchema>;

--- a/app/backend/src/server.ts
+++ b/app/backend/src/server.ts
@@ -4,13 +4,11 @@ import rateLimit from 'express-rate-limit';
 import * as path from 'path';
 import * as trpcExpress from '@trpc/server/adapters/express';
 import { initTRPC } from '@trpc/server';
-import { updateCommitStatus } from './updateCommitStatus';
 import { fetchCurrentPage } from './fetchCurrentPage';
 import { updateBaseImagesInS3 } from './updateBaseImagesInS3';
 import {
   fetchCurrentPageInputSchema,
-  updateBaseImagesInputSchema,
-  updateCommitStatusInputSchema
+  updateBaseImagesInputSchema
 } from './schema';
 
 const t = initTRPC.create();
@@ -21,10 +19,7 @@ const router = t.router({
     .query(({ input }) => fetchCurrentPage(input)),
   updateBaseImages: t.procedure
     .input(updateBaseImagesInputSchema)
-    .mutation(({ input }) => updateBaseImagesInS3(input)),
-  updateCommitStatus: t.procedure
-    .input(updateCommitStatusInputSchema)
-    .mutation(({ input }) => updateCommitStatus(input))
+    .mutation(({ input }) => updateBaseImagesInS3(input))
 });
 
 export type AppRouter = typeof router;

--- a/app/backend/src/updateBaseImagesInS3.ts
+++ b/app/backend/src/updateBaseImagesInS3.ts
@@ -4,6 +4,7 @@ import { findReasonToPreventBaseImageUpdate } from './findReasonToPreventBaseIma
 import { TRPCError } from '@trpc/server';
 import { UpdateBaseImagesInput } from './schema';
 import { getKeysFromS3 } from './getKeysFromS3';
+import { updateCommitStatus } from './updateCommitStatus';
 
 export const updateBaseImagesInS3 = async ({
   hash,
@@ -23,7 +24,8 @@ export const updateBaseImagesInS3 = async ({
     });
   }
   const s3Paths = await getKeysFromS3(hash, bucket);
-  return await replaceImagesInS3(s3Paths, bucket);
+  await replaceImagesInS3(s3Paths, bucket);
+  await updateCommitStatus({ owner, repo, hash });
 };
 
 export const filterNewImages = (s3Paths: string[]) => {

--- a/app/backend/src/updateCommitStatus.ts
+++ b/app/backend/src/updateCommitStatus.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { UpdateCommitStatusInput } from './schema';
+import { UpdateBaseImagesInput } from './schema';
 import { getOctokit } from './getOctokit';
 import { VISUAL_REGRESSION_CONTEXT } from 'shared';
 
@@ -7,7 +7,7 @@ export const updateCommitStatus = async ({
   owner,
   repo,
   hash
-}: UpdateCommitStatusInput) => {
+}: Omit<UpdateBaseImagesInput, 'bucket'>) => {
   const octokit = getOctokit(owner, repo);
   return octokit.rest.repos
     .createCommitStatus({

--- a/app/backend/test/getOctokit.test.ts
+++ b/app/backend/test/getOctokit.test.ts
@@ -1,9 +1,11 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { getOctokit } from '../src/getOctokit';
 import { Octokit } from '@octokit/rest';
 
 jest.mock('fs');
 jest.mock('@octokit/rest');
+
+(existsSync as jest.Mock).mockReturnValue(true);
 
 describe('getOctokitOptions', () => {
   it('should read secrets and generate octokit options', () => {
@@ -29,7 +31,7 @@ describe('getOctokitOptions', () => {
       toString: jest.fn(() => JSON.stringify({}))
     }));
     expect(() => getOctokit('github-owner', 'github-repo')).toThrow(
-      /No GitHub configs were found for github-owner\/github-repo/
+      /Failed to parse secrets.json/
     );
   });
 });

--- a/app/backend/test/getOctokit.test.ts
+++ b/app/backend/test/getOctokit.test.ts
@@ -26,7 +26,7 @@ describe('getOctokitOptions', () => {
     });
   });
 
-  it('throws error if config not found', () => {
+  it('throws error if token not found', () => {
     (readFileSync as jest.Mock).mockImplementation(() => ({
       toString: jest.fn(() => JSON.stringify({}))
     }));

--- a/app/backend/test/getOctokit.test.ts
+++ b/app/backend/test/getOctokit.test.ts
@@ -31,7 +31,7 @@ describe('getOctokitOptions', () => {
       toString: jest.fn(() => JSON.stringify({}))
     }));
     expect(() => getOctokit('github-owner', 'github-repo')).toThrow(
-      /Failed to parse secrets.json/
+      'Missing githubToken for repo github-owner/github-repo'
     );
   });
 });

--- a/app/backend/test/updateBaseImagesInS3.test.ts
+++ b/app/backend/test/updateBaseImagesInS3.test.ts
@@ -7,9 +7,11 @@ import {
 } from '../src/updateBaseImagesInS3';
 import { BASE_IMAGES_DIRECTORY } from 'shared';
 import { findReasonToPreventBaseImageUpdate } from '../src/findReasonToPreventBaseImageUpdate';
+import { updateCommitStatus } from '../src/updateCommitStatus';
 
 jest.mock('../src/findReasonToPreventBaseImageUpdate');
 jest.mock('../src/s3Client');
+jest.mock('../src/updateCommitStatus');
 
 describe('filterNewImages', () => {
   it('should filter only the new images from the given paths', () => {
@@ -93,5 +95,6 @@ describe('updateBaseImagesInS3', () => {
 
     expect(S3Client.listObjectsV2).not.toHaveBeenCalled();
     expect(S3Client.copyObject).not.toHaveBeenCalled();
+    expect(updateCommitStatus).not.toHaveBeenCalled();
   });
 });

--- a/app/backend/tsconfig.json
+++ b/app/backend/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./**/*"]
+  "include": ["./**/*", "../../reset.d.ts"]
 }

--- a/app/frontend/components/image-views.tsx
+++ b/app/frontend/components/image-views.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { RouterOutput } from '../utils/trpc';
 import { PrimaryButton, SecondaryButton } from './buttons';
-import { FileName } from '../../backend/src/schema';
 
 type Images = RouterOutput['fetchCurrentPage']['images'];
 interface ImageViewChildProps {
   images: Images;
 }
+export type Image = Images[number];
 
 interface SingleImageViewProps extends ImageViewChildProps {
-  selectedImage: FileName;
-  setSelectedImage: (file: FileName) => void;
+  selectedImage?: Image;
+  setSelectedImage: (file: Image) => void;
 }
 
 export const SingleImageView: React.FC<SingleImageViewProps> = ({
@@ -18,20 +18,17 @@ export const SingleImageView: React.FC<SingleImageViewProps> = ({
   selectedImage,
   setSelectedImage
 }) => {
-  const currentImage = images.find(image => image.name === selectedImage);
-  const firstImageName = images.find(Boolean)?.name;
-  if (!currentImage && firstImageName) {
-    setSelectedImage(firstImageName);
-    return null;
+  if (!selectedImage) {
+    return <p>No images found.</p>;
   }
 
   return (
     <div className="mb-12 mt-5 flex justify-center">
       <div className="fixed bottom-20">
         {images.map((image, index) => {
-          const onClick = () => setSelectedImage(image.name);
+          const onClick = () => setSelectedImage(image);
           const Button =
-            selectedImage === image.name ? PrimaryButton : SecondaryButton;
+            selectedImage.name === image.name ? PrimaryButton : SecondaryButton;
           const extraStyles = getImageButtonStyles(images, index);
           return (
             <Button
@@ -45,7 +42,7 @@ export const SingleImageView: React.FC<SingleImageViewProps> = ({
           );
         })}
       </div>
-      <img src={currentImage?.url} alt={currentImage?.name} />
+      <img src={selectedImage.url} alt={selectedImage.name} />
     </div>
   );
 };

--- a/app/frontend/components/image-views.tsx
+++ b/app/frontend/components/image-views.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { RouterOutput } from '../utils/trpc';
 import { PrimaryButton, SecondaryButton } from './buttons';
+import { FileName } from '../../backend/src/schema';
 
 type Images = RouterOutput['fetchCurrentPage']['images'];
 interface ImageViewChildProps {
@@ -8,17 +9,19 @@ interface ImageViewChildProps {
 }
 
 interface SingleImageViewProps extends ImageViewChildProps {
-  selectedImageIndex: number;
-  onSelectImage: (index: number) => void;
+  selectedImage: FileName;
+  setSelectedImage: (file: FileName) => void;
 }
 
 export const SingleImageView: React.FC<SingleImageViewProps> = ({
   images,
-  selectedImageIndex,
-  onSelectImage
+  selectedImage,
+  setSelectedImage
 }) => {
-  if (!images[selectedImageIndex]) {
-    onSelectImage(0);
+  const currentImage = images.find(image => image.name === selectedImage);
+  const firstImageName = images.find(Boolean)?.name;
+  if (!currentImage && firstImageName) {
+    setSelectedImage(firstImageName);
     return null;
   }
 
@@ -26,9 +29,9 @@ export const SingleImageView: React.FC<SingleImageViewProps> = ({
     <div className="mb-12 mt-5 flex justify-center">
       <div className="fixed bottom-20">
         {images.map((image, index) => {
-          const onClick = () => onSelectImage(index);
+          const onClick = () => setSelectedImage(image.name);
           const Button =
-            selectedImageIndex === index ? PrimaryButton : SecondaryButton;
+            selectedImage === image.name ? PrimaryButton : SecondaryButton;
           const extraStyles = getImageButtonStyles(images, index);
           return (
             <Button
@@ -42,10 +45,7 @@ export const SingleImageView: React.FC<SingleImageViewProps> = ({
           );
         })}
       </div>
-      <img
-        src={images[selectedImageIndex]?.url}
-        alt={images[selectedImageIndex]?.name}
-      />
+      <img src={currentImage?.url} alt={currentImage?.name} />
     </div>
   );
 };

--- a/app/frontend/components/main-page.tsx
+++ b/app/frontend/components/main-page.tsx
@@ -5,7 +5,7 @@ import { Error } from './error';
 import { Loader, LoaderViews } from './loader';
 import { ViewToggle, ImageViews, ImageView } from './view-toggle';
 import { UpdateImagesButton } from './update-images-button';
-import { SideBySideImageView, SingleImageView } from './image-views';
+import { Image, SideBySideImageView, SingleImageView } from './image-views';
 import { RouterOutput, trpc } from '../utils/trpc';
 import {
   createSearchParams,
@@ -13,13 +13,11 @@ import {
   useSearchParams
 } from 'react-router-dom';
 import { ArrowBackIcon, ArrowForwardIcon } from './arrows';
-import { FILE_NAMES, FileName } from '../../backend/src/schema';
+import { FILE_NAMES } from '../../backend/src/schema';
 
 export const MainPage = () => {
   const [viewType, setViewType] = React.useState<ImageView | undefined>();
-  const [selectedImage, setSelectedImage] = React.useState<FileName>(
-    FILE_NAMES.DIFF
-  );
+  const [selectedImage, setSelectedImage] = React.useState<Image>();
 
   const [searchParams] = useSearchParams();
   const params: Record<string, string | undefined> = Object.fromEntries(
@@ -37,7 +35,7 @@ export const MainPage = () => {
   const nextPageExists = Boolean(data?.nextPage);
 
   const navigate = useNavigate();
-  const utils = trpc.useContext();
+  const utils = trpc.useUtils();
   if (nextPageExists) {
     utils.fetchCurrentPage.prefetch({ hash, bucket, page: page + 1 });
   }
@@ -82,7 +80,11 @@ export const MainPage = () => {
       ) : (
         <SingleImageView
           images={data.images}
-          selectedImage={selectedImage}
+          selectedImage={
+            selectedImage ??
+            data.images.find(image => image.name === FILE_NAMES.DIFF) ??
+            data.images[0]
+          }
           setSelectedImage={setSelectedImage}
         />
       );

--- a/app/frontend/components/main-page.tsx
+++ b/app/frontend/components/main-page.tsx
@@ -13,10 +13,13 @@ import {
   useSearchParams
 } from 'react-router-dom';
 import { ArrowBackIcon, ArrowForwardIcon } from './arrows';
+import { FILE_NAMES, FileName } from '../../backend/src/schema';
 
 export const MainPage = () => {
   const [viewType, setViewType] = React.useState<ImageView | undefined>();
-  const [singleImageViewIndex, setSingleImageViewIndex] = React.useState(1);
+  const [selectedImage, setSelectedImage] = React.useState<FileName>(
+    FILE_NAMES.DIFF
+  );
 
   const [searchParams] = useSearchParams();
   const params: Record<string, string | undefined> = Object.fromEntries(
@@ -79,8 +82,8 @@ export const MainPage = () => {
       ) : (
         <SingleImageView
           images={data.images}
-          selectedImageIndex={singleImageViewIndex}
-          onSelectImage={setSingleImageViewIndex}
+          selectedImage={selectedImage}
+          setSelectedImage={setSelectedImage}
         />
       );
     return <div className="mt-8">{imageView}</div>;

--- a/app/frontend/components/main-page.tsx
+++ b/app/frontend/components/main-page.tsx
@@ -5,7 +5,11 @@ import { Error } from './error';
 import { Loader, LoaderViews } from './loader';
 import { ViewToggle, ImageViews, ImageView } from './view-toggle';
 import { UpdateImagesButton } from './update-images-button';
-import { Image, SideBySideImageView, SingleImageView } from './image-views';
+import {
+  type Image,
+  SideBySideImageView,
+  SingleImageView
+} from './image-views';
 import { RouterOutput, trpc } from '../utils/trpc';
 import {
   createSearchParams,

--- a/app/frontend/cypress/component/App.cy.tsx
+++ b/app/frontend/cypress/component/App.cy.tsx
@@ -16,7 +16,7 @@ import { mutationResponse } from '../mocks/mutation';
 import { MemoryRouter } from 'react-router-dom';
 
 const getPageFromRequest = (req: CyHttpMessages.IncomingHttpRequest) =>
-  JSON.parse(req.query.input as string)['0'].page;
+  (JSON.parse(req.query.input as string) as any)['0'].page;
 
 describe('App', () => {
   describe('homepage', () => {

--- a/app/frontend/cypress/component/App.cy.tsx
+++ b/app/frontend/cypress/component/App.cy.tsx
@@ -40,9 +40,6 @@ describe('App', () => {
       cy.intercept('/trpc/updateBaseImages*', { body: mutationResponse }).as(
         'base-images'
       );
-      cy.intercept('/trpc/updateCommitStatus*', { body: mutationResponse }).as(
-        'commit-status'
-      );
       cy.mount(
         <MemoryRouter
           initialEntries={['/?hash=123&bucket=bucket&repo=repo&owner=owner']}
@@ -121,7 +118,7 @@ describe('App', () => {
       cy.findByRole('button', { name: /Update all base images/i }).click();
       cy.findByText(/Are you sure/i);
       cy.findByRole('button', { name: /update/i }).click();
-      cy.wait(['@base-images', '@commit-status']);
+      cy.wait('@base-images');
       cy.findByRole('button', { name: /all images updated/i });
     });
 
@@ -138,7 +135,7 @@ describe('App', () => {
       cy.findByRole('button', { name: /Update all base images/i }).click();
       cy.findByText(/Are you sure/i);
       cy.findByRole('button', { name: /update/i }).click();
-      cy.wait(['@base-images', '@commit-status']);
+      cy.wait('@base-images');
       cy.findByRole('button', { name: /all images updated/i }).should(
         'be.disabled'
       );

--- a/app/frontend/tsconfig.json
+++ b/app/frontend/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./**/*"]
+  "include": ["./**/*", "../../reset.d.ts"]
 }

--- a/comparadise-utils/tsconfig.json
+++ b/comparadise-utils/tsconfig.json
@@ -6,5 +6,5 @@
     "noEmit": false,
     "outDir": "dist"
   },
-  "include": ["./**/*"]
+  "include": ["./**/*", "../reset.d.ts"]
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["./**/*"]
+  "include": ["./**/*", "../reset.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "packageManager": "pnpm@8.6.2",
   "devDependencies": {
     "@swc/jest": "0.2.29",
+    "@total-typescript/ts-reset": "0.5.1",
     "@types/jest": "29.5.5",
     "@typescript-eslint/eslint-plugin": "6.8.0",
     "cypress": "13.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@swc/jest':
         specifier: 0.2.29
         version: 0.2.29(@swc/core@1.3.96)
+      '@total-typescript/ts-reset':
+        specifier: 0.5.1
+        version: 0.5.1
       '@types/jest':
         specifier: 29.5.5
         version: 29.5.5
@@ -5029,6 +5032,10 @@ packages:
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       pretty-format: 27.5.1
+    dev: true
+
+  /@total-typescript/ts-reset@0.5.1:
+    resolution: {integrity: sha512-AqlrT8YA1o7Ff5wPfMOL0pvL+1X+sw60NN6CcOCqs658emD6RfiXhF7Gu9QcfKBH7ELY2nInLhKSCWVoNL70MQ==}
     dev: true
 
   /@trpc/client@10.43.3(@trpc/server@10.43.3):

--- a/reset.d.ts
+++ b/reset.d.ts
@@ -1,0 +1,2 @@
+// https://github.com/total-typescript/ts-reset
+import '@total-typescript/ts-reset';

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["./**/*"]
+  "include": ["./**/*", "../reset.d.ts"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Use file names for state management rather than indices
- Absorbs updateCommitStatus endpoint into updateBaseImages, since it's really one operation
- Pull in [ts-reset](https://github.com/total-typescript/ts-reset/) library for smarter type checking
- Add schema validation for secrets.json
