### PR TITLE
fix: overwrite screenshot on retry

### DIFF
--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -90,12 +90,17 @@ export function matchScreenshot(
 
   const { name, screenshotsFolder } = getTestFolderPathFromScripts(rawName);
 
+  const screenshotOptions: Partial<Cypress.ScreenshotOptions> = {
+    overwrite: true,
+    ...options
+  };
+
   cy.task('baseExists', screenshotsFolder).then(hasBase => {
     const target = subject ? cy.wrap(subject) : cy;
     // For easy slicing of path ignoring the root screenshot folder
     target.screenshot(
       `${PREFIX_DIFFERENTIATOR}${screenshotsFolder}/new`,
-      options
+      screenshotOptions
     );
 
     if (!hasBase) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
This should solve issues like [this](https://github.expedia.biz/Brand-Expedia/shopping-pwa/actions/runs/23934789/job/37138476#step:7:247):
1. for the first time when test fails - image is not taken; hence `new.png` is not created
2. for subsequent retries, when test might be able to get to the step of taking screenshot - image created with name 'new (attempt x).png` ([see name convention](https://docs.cypress.io/api/commands/screenshot#Naming-conventions))
3. [later](https://github.com/ExpediaGroup/comparadise/blob/e5e73f0ee0cb852cff132e651a35f8c46403eaeb/comparadise-utils/images.ts#L72) when calculating the diff between new and base images we trying to get new image by [new.png](https://github.com/ExpediaGroup/comparadise/blob/e5e73f0ee0cb852cff132e651a35f8c46403eaeb/comparadise-utils/screenshots.ts#L30) name, which doesn't exists
4. test fails because of the point 3, then initiating another retry

### :link: Related Issues
- 
