### PR TITLE
fix: trim attempt postfix from image name

### DIFF
--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -53,6 +53,28 @@ export function compareScreenshots(screenshotFolder: string) {
   return diffPixels;
 }
 
+const trimPostfix = (path: string) => {
+  const imgExt = '.png';
+  const attemptPostfixRegex = new RegExp(`\\s\\(attempt \\d+\\)${imgExt}$`);
+
+  if (attemptPostfixRegex.test(path)) {
+    return path.replace(attemptPostfixRegex, imgExt);
+  }
+
+  return path;
+};
+
+const getNewPath = (path: string) => {
+  let newPath = path.slice(path.lastIndexOf('___') + 3);
+  console.log(newPath);
+
+  if (newPath.startsWith('/')) {
+    newPath = `.${newPath}`;
+  }
+
+  return trimPostfix(newPath);
+};
+
 /**
  * Renames all root cypress screenshots to where the test was actually run.
  * Should NOT be used standalone. Works with the matchScreenshot task.
@@ -65,17 +87,6 @@ export function onAfterScreenshot(
   if (!details.path.match('cypress')) {
     return Promise.resolve({});
   }
-
-  const getNewPath = (path: string) => {
-    let newPath = path.slice(path.lastIndexOf('___') + 3);
-    console.log(newPath);
-
-    if (newPath.startsWith('/')) {
-      newPath = `.${newPath}`;
-    }
-
-    return newPath;
-  };
 
   const newPath = getNewPath(details.path);
   const newPathDir = newPath.substring(0, newPath.lastIndexOf('/'));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
This should solve issues like this:

```
🧸 Screenshot was saved to: /new (attempt 2).png
screenshots/property-compare-properties-selected-SMALL/new (attempt 2).png
🧸 Screenshot was saved to: /new (attempt 3).png
screenshots/property-compare-properties-selected-SMALL/new (attempt 3).png
🧸 Screenshot was saved to: /new (attempt 4).png
screenshots/property-compare-properties-selected-SMALL/new (attempt 4).png
🧸 Screenshot was saved to: /new (attempt 5).png
screenshots/property-compare-properties-selected-SMALL/new (attempt 5).png
    1) Bottom sheet with 5 properties selected
    ✓ Dialog (11073ms)


  4 passing (2m)
  1 failing

  1) SRP: Property Comparison test (Size: SMALL)
       Bottom sheet with 5 properties selected:
     CypressError: `cy.task('compareScreenshots')` failed with the following error:

> ENOENT: no such file or directory, open '/new.png'
```

1. for the first time when test fails - image is not taken; hence `new.png` is not created
2. for subsequent retries, when test might be able to get to the step of taking screenshot - image created with name 'new (attempt x).png` ([see name convention](https://docs.cypress.io/api/commands/screenshot#Naming-conventions))
3. [later](https://github.com/ExpediaGroup/comparadise/blob/e5e73f0ee0cb852cff132e651a35f8c46403eaeb/comparadise-utils/images.ts#L72) when calculating the diff between new and base images we trying to get new image by [new.png](https://github.com/ExpediaGroup/comparadise/blob/e5e73f0ee0cb852cff132e651a35f8c46403eaeb/comparadise-utils/screenshots.ts#L30) name, which doesn't exists
4. test fails because of the point 3, then initiating another retry and eventually failing the test

The solution is to trim the `(attempt x)` postfix from the image name after screenshot is taken

### :link: Related Issues
- 
