### PR TITLE
fix: screenshot location on local machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IntelliJ
 .idea
+comparadise.iml
 
 # dependencies
 node_modules

--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -65,11 +65,15 @@ const trimPostfix = (path: string) => {
 };
 
 const getNewPath = (path: string) => {
-  let newPath = path.slice(path.lastIndexOf('___') + 3);
-  console.log(newPath);
-
-  if (newPath.startsWith('/')) {
-    newPath = `.${newPath}`;
+  let newPath;
+  if (path.includes('___')) {
+    newPath = path.slice(path.lastIndexOf('___') + 3);
+    if (newPath.startsWith('/')) {
+      newPath = `.${newPath}`;
+    }
+    console.log(newPath);
+  } else {
+    newPath = path;
   }
 
   return trimPostfix(newPath);


### PR DESCRIPTION
### :pencil: Description
fix: screenshot location on local machine

The screenshots path is getting trimmed. e.g. 
The screenshot should be saved to:
```
/Users/swarule/expcode/shared-ui-web/cypress/screenshots/test-xyz/xyz -- Desktop -- render (failed).png
```

It is getting saved to:
```
sers/swarule/expcode/shared-ui-web/cypress/screenshots/test-xyz/xyz -- Desktop -- render (failed).png
```
It is happening because path does not include `___`. So `path.lastIndexOf('___')` returns `-1`. That is the reason of first 2 letters getting trimmed.
`gegtNewPath` is used in `onAfterScreenshot` which stores the screenshots for failed component tests.

After this change, the screenshots should be saved to original location locally.

### :link: Related Issues
- 
