### PR TITLE
fix: use Uint8Array for diff file writing

### DIFF
--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -35,7 +35,7 @@ export function compareScreenshots(screenshotFolder: string) {
     // Create diff.png next to base and new for review
     fs.writeFile(
       createImageFileName(screenshotFolder, 'diff'),
-      PNG.sync.write(diff).toString(),
+      new Uint8Array(PNG.sync.write(diff)),
       err => {
         if (err) {
           console.error('❌ Diff exists but unable to create diff.png', err);


### PR DESCRIPTION
### :pencil: Description

fix: use Uint8Array for diff file writing

diff image is not getting saved properly. While converting the buffer of image file to string the headers are getting corrupted.
```
>>> magick identify diff.png
identify: improper image header `diff.png' @ error/png.c/ReadPNGImage/3942.

>>> pngcheck diff.png
diff.png  this is neither a PNG or JNG image nor a MNG stream
ERROR: diff.png
```
<img width="254" alt="Screenshot 2024-12-02 at 1 56 13 PM" src="https://github.com/user-attachments/assets/e9552d60-559e-49cd-82a4-0a225a4f9215">


Whereas the base images are getting stored properly
```
>>> magick identify base.png
base.png PNG 2000x1320 2000x1320+0+0 8-bit sRGB 543579B 0.000u 0:00.003
```

Tested locally with `Uint8Array`, diff.png is getting stored properly.