### PR TITLE
fix: set job to failed when visual regression found

### DIFF
--- a/action/src/run.ts
+++ b/action/src/run.ts
@@ -159,4 +159,5 @@ export const run = async () => {
     ...context.repo
   });
   await createGithubComment();
+  setFailed('Visual regression detected. Check the comment for more details.');
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- This pr is to set the action to failed if a visual regression is found. Currently we only create a commit message without explicity setting the job to failed in this scenario.

### :link: Related Issues
- https://jira.expedia.biz/browse/FUSEFND-579 
