### PR TITLE
fix: tune visual regression tests to be less sensitive

### DIFF
--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -3,7 +3,9 @@ import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
 const PIXELMATCH_OPTIONS = {
-  threshold: 0.3
+  alpha: 0.3, // defaults to 0.1
+  threshold: 0.5, // defaults to 0.1
+  includeAA: false // defaults to true
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- First iteration of tuning visual tests to be less sensitive to reduce failures on tiny/minor discrepancies
- Bump `alpha` value to 0.3 from default value of 0.1 to provide a more opaque diff overlay
- Bump `threshold` from 0.3 to 0.5 to allow a slightly higher color difference between images
- Set `includeAA` to false instead of using its default value of true to exclude anti-aliasing differences

### :link: Related Issues
- FUSEFND-581
