### PR TITLE
chore: tune visual tests pt 2

### DIFF
--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -3,8 +3,8 @@ import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
 const PIXELMATCH_OPTIONS = {
-  alpha: 0.3, // defaults to 0.1
-  threshold: 0.5, // defaults to 0.1
+  alpha: 0.4, // defaults to 0.1
+  threshold: 0.6, // defaults to 0.1
   includeAA: false // defaults to true
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Bump threshold to 0.6
- Bump alpha to 0.4

With the last sensitivity tuning, was still seeing minor text discrepancies being regarding as failures.
<img width="1156" alt="Screenshot 2025-03-31 at 4 37 05 PM" src="https://github.com/user-attachments/assets/bdfbe922-39f8-4bff-9a8f-43c5838561e1" />

Hoping that this helps reduce the likelihood of that happening.

### :link: Related Issues
- FUSEFND-581
