### PR TITLE
feat: make visual regression sensitivity configurable from client

### DIFF
--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -9,14 +9,14 @@ const PIXELMATCH_OPTIONS = {
 };
 
 export type PixelMatchOptions = {
-  threshold?: number | undefined,
-  includeAA?: boolean | undefined,
-  alpha?: number | undefined,
-  aaColor?: [number, number, number] | undefined,
-  diffColor?: [number, number, number] | undefined,
-  diffColorAlt?: [number, number, number] | undefined,
-  diffMask?: boolean | undefined
-}
+  threshold?: number | undefined;
+  includeAA?: boolean | undefined;
+  alpha?: number | undefined;
+  aaColor?: [number, number, number] | undefined;
+  diffColor?: [number, number, number] | undefined;
+  diffColorAlt?: [number, number, number] | undefined;
+  diffMask?: boolean | undefined;
+};
 
 /**
  * Helper function to create reusable image resizer
@@ -80,7 +80,11 @@ function alignImagesToSameSize(firstImage: PNG, secondImage: PNG) {
  * @param {string} actualPath - Full file path to new image
  * @param pixelMatchOptions - (Optional) options to calculate pixel differences between two images
  */
-export function getDiffPixels(basePath: string, actualPath: string, pixelMatchOptions: PixelMatchOptions = PIXELMATCH_OPTIONS) {
+export function getDiffPixels(
+  basePath: string,
+  actualPath: string,
+  pixelMatchOptions: PixelMatchOptions = PIXELMATCH_OPTIONS
+) {
   const rawBase = PNG.sync.read(fs.readFileSync(basePath));
   const rawActual = PNG.sync.read(fs.readFileSync(actualPath));
 

--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -78,7 +78,7 @@ function alignImagesToSameSize(firstImage: PNG, secondImage: PNG) {
  * and diff PNG for writing the diff image to.
  * @param {string} basePath - Full file path to base image
  * @param {string} actualPath - Full file path to new image
- * @param pixelMatchOptions - options to calculate pixel differences between two images
+ * @param pixelMatchOptions - (Optional) options to calculate pixel differences between two images
  */
 export function getDiffPixels(basePath: string, actualPath: string, pixelMatchOptions: PixelMatchOptions = PIXELMATCH_OPTIONS) {
   const rawBase = PNG.sync.read(fs.readFileSync(basePath));

--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -8,6 +8,16 @@ const PIXELMATCH_OPTIONS = {
   includeAA: false // defaults to true
 };
 
+export type PixelMatchOptions = {
+  threshold?: number | undefined,
+  includeAA?: boolean | undefined,
+  alpha?: number | undefined,
+  aaColor?: [number, number, number] | undefined,
+  diffColor?: [number, number, number] | undefined,
+  diffColorAlt?: [number, number, number] | undefined,
+  diffMask?: boolean | undefined
+}
+
 /**
  * Helper function to create reusable image resizer
  */
@@ -68,8 +78,9 @@ function alignImagesToSameSize(firstImage: PNG, secondImage: PNG) {
  * and diff PNG for writing the diff image to.
  * @param {string} basePath - Full file path to base image
  * @param {string} actualPath - Full file path to new image
+ * @param pixelMatchOptions - options to calculate pixel differences between two images
  */
-export function getDiffPixels(basePath: string, actualPath: string) {
+export function getDiffPixels(basePath: string, actualPath: string, pixelMatchOptions: PixelMatchOptions = PIXELMATCH_OPTIONS) {
   const rawBase = PNG.sync.read(fs.readFileSync(basePath));
   const rawActual = PNG.sync.read(fs.readFileSync(actualPath));
 
@@ -91,7 +102,7 @@ export function getDiffPixels(basePath: string, actualPath: string) {
     diff.data,
     diff.width,
     diff.height,
-    PIXELMATCH_OPTIONS
+    pixelMatchOptions
   );
 
   return { diffPixels, diff };

--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -2,21 +2,13 @@ import * as fs from 'fs';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
-const PIXELMATCH_OPTIONS = {
+const PIXELMATCH_OPTIONS: PixelMatchOptions = {
   alpha: 0.3, // defaults to 0.1
   threshold: 0.5, // defaults to 0.1
   includeAA: false // defaults to true
 };
 
-export interface PixelMatchOptions {
-  threshold?: number | undefined;
-  includeAA?: boolean | undefined;
-  alpha?: number | undefined;
-  aaColor?: [number, number, number] | undefined;
-  diffColor?: [number, number, number] | undefined;
-  diffColorAlt?: [number, number, number] | undefined;
-  diffMask?: boolean | undefined;
-}
+export type PixelMatchOptions = Parameters<typeof pixelmatch>[5];
 
 /**
  * Helper function to create reusable image resizer

--- a/comparadise-utils/images.ts
+++ b/comparadise-utils/images.ts
@@ -8,7 +8,7 @@ const PIXELMATCH_OPTIONS = {
   includeAA: false // defaults to true
 };
 
-export type PixelMatchOptions = {
+export interface PixelMatchOptions {
   threshold?: number | undefined;
   includeAA?: boolean | undefined;
   alpha?: number | undefined;
@@ -16,7 +16,7 @@ export type PixelMatchOptions = {
   diffColor?: [number, number, number] | undefined;
   diffColorAlt?: [number, number, number] | undefined;
   diffMask?: boolean | undefined;
-};
+}
 
 /**
  * Helper function to create reusable image resizer

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -74,20 +74,18 @@ function verifyImages() {
   }
 }
 
-interface SensitivityOptions {
-  pixelMatchOptions?: PixelMatchOptions;
-}
-
 export type MatchScreenshotArgs = {
   rawName?: string;
-  options?: Partial<Cypress.ScreenshotOptions> & SensitivityOptions;
+  options?: Partial<Cypress.ScreenshotOptions> & {
+    pixelMatchOptions?: PixelMatchOptions;
+  };
 };
 
 export function matchScreenshot(
   subject: Cypress.JQueryWithSelector | Window | Document | void,
   args?: MatchScreenshotArgs
 ) {
-  const { rawName, options = undefined } = args || {};
+  const { rawName, options } = args || {};
   // Set up screen
   forceFont();
 

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -78,11 +78,9 @@ interface SensitivityOptions {
   pixelMatchOptions?: PixelMatchOptions;
 }
 
-export type Options = Partial<Cypress.ScreenshotOptions> & SensitivityOptions;
-
 export type MatchScreenshotArgs = {
   rawName?: string;
-  options?: Options;
+  options?: Partial<Cypress.ScreenshotOptions> & SensitivityOptions;
 };
 
 export function matchScreenshot(

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -91,7 +91,7 @@ export function matchScreenshot(
   // Making sure each image is visible before taking screenshots
   verifyImages();
 
-  const { name, screenshotsFolder } = getTestFolderPathFromScripts(rawName);
+  const { name, screenshotsFolder, pixelMatchSettings } = getTestFolderPathFromScripts(rawName);
 
   cy.task('baseExists', screenshotsFolder).then(hasBase => {
     const target = subject ? cy.wrap(subject) : cy;
@@ -109,8 +109,10 @@ export function matchScreenshot(
 
       return null;
     }
+    
+    const compareScreenshotsArg = { screenshotsFolder, pixelMatchSettings }
 
-    cy.task('compareScreenshots', screenshotsFolder).then(diffPixels => {
+    cy.task('compareScreenshots', compareScreenshotsArg).then(diffPixels => {
       if (diffPixels === 0) {
         cy.log(`✅ Actual image of ${name} was the same as base`);
       } else {

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -84,15 +84,14 @@ export function matchScreenshot(
   subject: Cypress.JQueryWithSelector | Window | Document | void,
   args?: MatchScreenshotArgs
 ) {
-  const { rawName, options = {} } = args || {};
+  const { rawName, options = {}, pixelMatchSettings } = args || {};
   // Set up screen
   forceFont();
 
   // Making sure each image is visible before taking screenshots
   verifyImages();
 
-  const { name, screenshotsFolder, pixelMatchSettings } =
-    getTestFolderPathFromScripts(rawName);
+  const { name, screenshotsFolder } = getTestFolderPathFromScripts(rawName);
 
   cy.task('baseExists', screenshotsFolder).then(hasBase => {
     const target = subject ? cy.wrap(subject) : cy;

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -113,7 +113,7 @@ export function matchScreenshot(
       return null;
     }
 
-    const pixelMatchOptions = options.pixelMatchOptions;
+    const pixelMatchOptions = options?.pixelMatchOptions;
     const compareScreenshotsArg = { screenshotsFolder, pixelMatchOptions };
 
     cy.task('compareScreenshots', compareScreenshotsArg).then(diffPixels => {

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -1,4 +1,4 @@
-import { PixelMatchOptions } from "./images";
+import { PixelMatchOptions } from './images';
 
 const PREFIX_DIFFERENTIATOR = '___';
 const SUFFIX_TEST_IDENTIFIER = '.spec.ts';
@@ -77,7 +77,7 @@ function verifyImages() {
 export type MatchScreenshotArgs = {
   rawName?: string;
   options?: Partial<Cypress.ScreenshotOptions>;
-  pixelMatchSettings?: PixelMatchOptions
+  pixelMatchSettings?: PixelMatchOptions;
 };
 
 export function matchScreenshot(
@@ -91,7 +91,8 @@ export function matchScreenshot(
   // Making sure each image is visible before taking screenshots
   verifyImages();
 
-  const { name, screenshotsFolder, pixelMatchSettings } = getTestFolderPathFromScripts(rawName);
+  const { name, screenshotsFolder, pixelMatchSettings } =
+    getTestFolderPathFromScripts(rawName);
 
   cy.task('baseExists', screenshotsFolder).then(hasBase => {
     const target = subject ? cy.wrap(subject) : cy;
@@ -109,8 +110,8 @@ export function matchScreenshot(
 
       return null;
     }
-    
-    const compareScreenshotsArg = { screenshotsFolder, pixelMatchSettings }
+
+    const compareScreenshotsArg = { screenshotsFolder, pixelMatchSettings };
 
     cy.task('compareScreenshots', compareScreenshotsArg).then(diffPixels => {
       if (diffPixels === 0) {

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -1,3 +1,5 @@
+import { PixelMatchOptions } from "./images";
+
 const PREFIX_DIFFERENTIATOR = '___';
 const SUFFIX_TEST_IDENTIFIER = '.spec.ts';
 const SCREENSHOTS_FOLDER_NAME = 'screenshots';
@@ -75,6 +77,7 @@ function verifyImages() {
 export type MatchScreenshotArgs = {
   rawName?: string;
   options?: Partial<Cypress.ScreenshotOptions>;
+  pixelMatchSettings?: PixelMatchOptions
 };
 
 export function matchScreenshot(

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -87,7 +87,7 @@ export function matchScreenshot(
   subject: Cypress.JQueryWithSelector | Window | Document | void,
   args?: MatchScreenshotArgs
 ) {
-  const { rawName, options = null } = args || {};
+  const { rawName, options = undefined } = args || {};
   // Set up screen
   forceFont();
 

--- a/comparadise-utils/match-screenshot.ts
+++ b/comparadise-utils/match-screenshot.ts
@@ -1,113 +1,157 @@
-import * as fs from 'fs';
-import { PNG } from 'pngjs';
-import pixelmatch from 'pixelmatch';
+import { PixelMatchOptions } from './images';
 
-const PIXELMATCH_OPTIONS = {
-  alpha: 0.3, // defaults to 0.1
-  threshold: 0.5, // defaults to 0.1
-  includeAA: false // defaults to true
-};
+const PREFIX_DIFFERENTIATOR = '___';
+const SUFFIX_TEST_IDENTIFIER = '.spec.ts';
+const SCREENSHOTS_FOLDER_NAME = 'screenshots';
 
-export interface PixelMatchOptions {
-  threshold?: number | undefined;
-  includeAA?: boolean | undefined;
-  alpha?: number | undefined;
-  aaColor?: [number, number, number] | undefined;
-  diffColor?: [number, number, number] | undefined;
-  diffColorAlt?: [number, number, number] | undefined;
-  diffMask?: boolean | undefined;
+function forceFont() {
+  const iframe = window.parent.document.querySelector('iframe');
+  const contentDocument = iframe && iframe.contentDocument;
+
+  if (contentDocument) {
+    const style = contentDocument.createElement('style');
+    style.type = 'text/css';
+    style.appendChild(
+      contentDocument.createTextNode('* { font-family: Arial !important; }')
+    );
+    contentDocument.head.appendChild(style);
+    return style;
+  }
+
+  return false;
 }
 
-/**
- * Helper function to create reusable image resizer
- */
-const createImageResizer = (width: number, height: number) => (source: PNG) => {
-  const resized = new PNG({ width, height, fill: true });
-  PNG.bitblt(source, resized, 0, 0, source.width, source.height, 0, 0);
-  return resized;
+function getTestFolderPathFromScripts(rawName?: string) {
+  const relativeTestPath = Cypress.spec.relative;
+
+  if (!relativeTestPath) {
+    throw new Error(
+      '❌ Could not find matching script in the Cypress DOM to infer the test folder path'
+    );
+  }
+
+  const currentTestNumber = Cypress.mocha.getRunner().currentRunnable?.order;
+  if (
+    !rawName &&
+    typeof currentTestNumber === 'number' &&
+    currentTestNumber > 1
+  ) {
+    throw new Error(
+      '❌ The rawName argument was not provided to matchScreenshot and is required for test files containing multiple tests!'
+    );
+  }
+
+  const testName = relativeTestPath.substring(
+    relativeTestPath.lastIndexOf('/') + 1,
+    relativeTestPath.lastIndexOf(SUFFIX_TEST_IDENTIFIER)
+  );
+  const name = rawName || testName;
+
+  const screenshotsFolder = `${SCREENSHOTS_FOLDER_NAME}/${relativeTestPath.substring(
+    0,
+    relativeTestPath.lastIndexOf(testName)
+  )}${name}`;
+
+  return {
+    name,
+    screenshotsFolder
+  };
+}
+
+function verifyImages() {
+  if (Cypress.$('img:visible').length > 0) {
+    cy.document()
+      .its('body')
+      .find('img')
+      .filter(':visible')
+      .then(images => {
+        if (images) {
+          cy.wrap(images).each($img => {
+            cy.wrap($img).should('exist').and('have.prop', 'naturalWidth');
+          });
+        }
+      });
+  }
+}
+
+interface SensitivityOptions {
+  pixelMatchOptions?: PixelMatchOptions;
+}
+
+export type Options = Partial<Cypress.ScreenshotOptions> & SensitivityOptions;
+
+export type MatchScreenshotArgs = {
+  rawName?: string;
+  options?: Options;
 };
 
-/**
- * Fills new area added after resize with transparent black color.
- * I like idea of checker board pattern, but it seems to be too complicated
- * to implement considering how low-level pngjs API is.
- */
-const fillSizeDifference = (width: number, height: number) => (image: PNG) => {
-  const inArea = (x: number, y: number) => y > height || x > width;
-  for (let y = 0; y < image.height; y++) {
-    for (let x = 0; x < image.width; x++) {
-      if (inArea(x, y)) {
-        const idx = (image.width * y + x) << 2;
-        image.data[idx] = 0;
-        image.data[idx + 1] = 0;
-        image.data[idx + 2] = 0;
-        image.data[idx + 3] = 64;
+export function matchScreenshot(
+  subject: Cypress.JQueryWithSelector | Window | Document | void,
+  args?: MatchScreenshotArgs
+) {
+  const { rawName, options = null } = args || {};
+  // Set up screen
+  forceFont();
+
+  // Making sure each image is visible before taking screenshots
+  verifyImages();
+
+  const { name, screenshotsFolder } = getTestFolderPathFromScripts(rawName);
+
+  cy.task('baseExists', screenshotsFolder).then(hasBase => {
+    const target = subject ? cy.wrap(subject) : cy;
+    // For easy slicing of path ignoring the root screenshot folder
+    target.screenshot(
+      `${PREFIX_DIFFERENTIATOR}${screenshotsFolder}/new`,
+      options
+    );
+
+    if (!hasBase) {
+      cy.task(
+        'log',
+        `✅ A new base image was created for ${name}. Create this as a new base image via Comparadise!`
+      );
+
+      return null;
+    }
+
+    const pixelMatchOptions = options.pixelMatchOptions;
+    const compareScreenshotsArg = { screenshotsFolder, pixelMatchOptions };
+
+    cy.task('compareScreenshots', compareScreenshotsArg).then(diffPixels => {
+      if (diffPixels === 0) {
+        cy.log(`✅ Actual image of ${name} was the same as base`);
+      } else {
+        throw new Error(
+          `❌ Actual image of ${name} differed by ${diffPixels} pixels.`
+        );
       }
+
+      return null;
+    });
+
+    return null;
+  });
+}
+
+Cypress.Commands.add(
+  'matchScreenshot',
+  { prevSubject: ['optional', 'element', 'window', 'document'] },
+  matchScreenshot
+);
+
+interface ExtendedCurrentRunnable extends Mocha.Runnable {
+  currentRunnable?: {
+    order?: unknown;
+  };
+}
+
+declare global {
+  namespace Cypress {
+    interface Cypress {
+      mocha: {
+        getRunner: () => ExtendedCurrentRunnable;
+      };
     }
   }
-  return image;
-};
-
-/**
- * Aligns images sizes to biggest common value
- * and fills new pixels with transparent pixels
- */
-function alignImagesToSameSize(firstImage: PNG, secondImage: PNG) {
-  // Keep original sizes to fill extended area later
-  const firstImageWidth = firstImage.width;
-  const firstImageHeight = firstImage.height;
-  const secondImageWidth = secondImage.width;
-  const secondImageHeight = secondImage.height;
-  // Calculate biggest common values
-  const resizeToSameSize = createImageResizer(
-    Math.max(firstImageWidth, secondImageWidth),
-    Math.max(firstImageHeight, secondImageHeight)
-  );
-  // Resize both images
-  const resizedFirst = resizeToSameSize(firstImage);
-  const resizedSecond = resizeToSameSize(secondImage);
-  // Fill resized area with black transparent pixels
-  return [
-    fillSizeDifference(firstImageWidth, firstImageHeight)(resizedFirst),
-    fillSizeDifference(secondImageWidth, secondImageHeight)(resizedSecond)
-  ];
-}
-
-/**
- * Compares a base and new image and returns the pixel difference
- * and diff PNG for writing the diff image to.
- * @param {string} basePath - Full file path to base image
- * @param {string} actualPath - Full file path to new image
- * @param pixelMatchOptions - (Optional) options to calculate pixel differences between two images
- */
-export function getDiffPixels(
-  basePath: string,
-  actualPath: string,
-  pixelMatchOptions: PixelMatchOptions = PIXELMATCH_OPTIONS
-) {
-  const rawBase = PNG.sync.read(fs.readFileSync(basePath));
-  const rawActual = PNG.sync.read(fs.readFileSync(actualPath));
-
-  const hasSizeMismatch =
-    rawBase.height !== rawActual.height || rawBase.width !== rawActual.width;
-
-  const [base, actual] = hasSizeMismatch
-    ? alignImagesToSameSize(rawBase, rawActual)
-    : [rawBase, rawActual];
-
-  if (!base || !actual) {
-    throw new Error();
-  }
-  const diff = new PNG({ width: base.width, height: base.height });
-
-  const diffPixels = pixelmatch(
-    actual.data,
-    base.data,
-    diff.data,
-    diff.width,
-    diff.height,
-    pixelMatchOptions
-  );
-
-  return { diffPixels, diff };
 }

--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -28,7 +28,7 @@ export type CompareScreenshotArgs = {
 
 /**
  * Runs a visual regression test.
- * @param args - 
+ * @param args -
  * Contains Full screenshots folder where the base/new/diff images will be compared and written to
  * Optionally contains specified Pixelmatch config settings.
  */

--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { PNG } from 'pngjs';
-import { getDiffPixels } from './images';
+import { getDiffPixels, PixelMatchOptions } from './images';
 import { createImageFileName } from './files';
 
 /**
@@ -21,15 +21,23 @@ export function baseExists(path: string) {
   return exists;
 }
 
+export type CompareScreenshotArgs = {
+  screenshotFolder: string;
+  pixelMatchSettings?: PixelMatchOptions
+}
+
 /**
  * Runs a visual regression test.
- * @param screenshotFolder - Full screenshots folder where the base/new/diff
- *                           images will be compared and written to.
+ * @param args - 
+ * Contains Full screenshots folder where the base/new/diff images will be compared and written to
+ * Optionally contains specified Pixelmatch config settings.
  */
-export function compareScreenshots(screenshotFolder: string) {
+export function compareScreenshots(args: CompareScreenshotArgs) {
+  const { screenshotFolder, pixelMatchSettings } = args || {};
+
   const basePath = createImageFileName(screenshotFolder, 'base');
   const actualPath = createImageFileName(screenshotFolder, 'new');
-  const { diffPixels, diff } = getDiffPixels(basePath, actualPath);
+  const { diffPixels, diff } = getDiffPixels(basePath, actualPath, pixelMatchSettings);
 
   if (diffPixels) {
     // Create diff.png next to base and new for review

--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -33,7 +33,7 @@ export type CompareScreenshotArgs = {
  * Optionally contains specified Pixelmatch config settings.
  */
 export function compareScreenshots(args: CompareScreenshotArgs) {
-  const { screenshotFolder, pixelMatchOptions } = args || {};
+  const { screenshotFolder, pixelMatchOptions } = args;
 
   const basePath = createImageFileName(screenshotFolder, 'base');
   const actualPath = createImageFileName(screenshotFolder, 'new');

--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -23,8 +23,8 @@ export function baseExists(path: string) {
 
 export type CompareScreenshotArgs = {
   screenshotFolder: string;
-  pixelMatchSettings?: PixelMatchOptions
-}
+  pixelMatchSettings?: PixelMatchOptions;
+};
 
 /**
  * Runs a visual regression test.
@@ -37,7 +37,11 @@ export function compareScreenshots(args: CompareScreenshotArgs) {
 
   const basePath = createImageFileName(screenshotFolder, 'base');
   const actualPath = createImageFileName(screenshotFolder, 'new');
-  const { diffPixels, diff } = getDiffPixels(basePath, actualPath, pixelMatchSettings);
+  const { diffPixels, diff } = getDiffPixels(
+    basePath,
+    actualPath,
+    pixelMatchSettings
+  );
 
   if (diffPixels) {
     // Create diff.png next to base and new for review

--- a/comparadise-utils/screenshots.ts
+++ b/comparadise-utils/screenshots.ts
@@ -23,7 +23,7 @@ export function baseExists(path: string) {
 
 export type CompareScreenshotArgs = {
   screenshotFolder: string;
-  pixelMatchSettings?: PixelMatchOptions;
+  pixelMatchOptions?: PixelMatchOptions;
 };
 
 /**
@@ -33,14 +33,14 @@ export type CompareScreenshotArgs = {
  * Optionally contains specified Pixelmatch config settings.
  */
 export function compareScreenshots(args: CompareScreenshotArgs) {
-  const { screenshotFolder, pixelMatchSettings } = args || {};
+  const { screenshotFolder, pixelMatchOptions } = args || {};
 
   const basePath = createImageFileName(screenshotFolder, 'base');
   const actualPath = createImageFileName(screenshotFolder, 'new');
   const { diffPixels, diff } = getDiffPixels(
     basePath,
     actualPath,
-    pixelMatchSettings
+    pixelMatchOptions
   );
 
   if (diffPixels) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Update `matchScreenshot` to take in optional args to specify the PixelMatch settings to control visual regression sensitivity from client usage of this function. If not explicitly passed from client, the sensitivity will be set to the default values found in [PIXELMATCH_OPTIONS](https://github.com/ExpediaGroup/comparadise/blob/main/comparadise-utils/images.ts#L5).
- This will enable individual tests to be uniquely configurable for sensitivity and also enable tuning changes from the client itself.

### :link: Related Issues

