### PR TITLE
fix: skip non-visual check gate when not updating base images

### DIFF
--- a/app/backend/src/acceptVisualChanges.ts
+++ b/app/backend/src/acceptVisualChanges.ts
@@ -19,7 +19,12 @@ export const acceptVisualChanges = async (
 ) => {
   const reasonToPreventUpdate =
     commitHash &&
-    (await findReasonToPreventVisualChangeAcceptance(owner, repo, commitHash));
+    (await findReasonToPreventVisualChangeAcceptance(
+      owner,
+      repo,
+      commitHash,
+      useBaseImages
+    ));
   if (reasonToPreventUpdate) {
     throw new TRPCError({
       code: 'FORBIDDEN',

--- a/app/backend/src/findReasonToPreventVisualChangeAcceptance.ts
+++ b/app/backend/src/findReasonToPreventVisualChangeAcceptance.ts
@@ -8,7 +8,8 @@ import {
 export const findReasonToPreventVisualChangeAcceptance = async (
   owner: string,
   repo: string,
-  sha: string
+  sha: string,
+  useBaseImages: boolean
 ) => {
   const octokit = getOctokit(owner, repo);
 
@@ -36,7 +37,7 @@ export const findReasonToPreventVisualChangeAcceptance = async (
   const nonVisualChecksThatHaveNotPassed = mostRecentNonVisualStatuses
     .filter(({ state }) => state !== 'success')
     .map(({ context }) => context);
-  if (nonVisualChecksThatHaveNotPassed.length) {
+  if (useBaseImages && nonVisualChecksThatHaveNotPassed.length) {
     return `All other PR checks must pass before updating base images! These checks have not passed on your PR: ${nonVisualChecksThatHaveNotPassed.join(
       ', '
     )}`;

--- a/app/backend/test/acceptVisualChanges.test.ts
+++ b/app/backend/test/acceptVisualChanges.test.ts
@@ -80,6 +80,38 @@ describe('acceptVisualChanges', () => {
     expect(updateCommitStatusMock).not.toHaveBeenCalled();
   });
 
+  it('should not throw if other checks have not passed when useBaseImages is false', async () => {
+    listCommitStatusesForRefMock.mockImplementationOnce(() => ({
+      data: [
+        {
+          context: 'unit tests',
+          state: 'success',
+          created_at: '2023-05-02T19:11:02Z'
+        },
+        {
+          context: 'other tests',
+          state: 'failure',
+          created_at: '2023-05-02T19:11:02Z'
+        }
+      ]
+    }));
+
+    const expectedBucket = 'expected-bucket-name';
+    await acceptVisualChanges(
+      {
+        commitHash: '030928b2c4b48ab4d3b57c8e0b0f7a56db768ef5',
+        bucket: expectedBucket,
+        useBaseImages: false,
+        repo: 'repo',
+        owner: 'owner'
+      },
+      { urlParams: {} }
+    );
+
+    expect(updateBaseImagesMock).not.toHaveBeenCalled();
+    expect(updateCommitStatusMock).toHaveBeenCalled();
+  });
+
   it('should update commit status but not base images if useBaseImages is false', async () => {
     const expectedBucket = 'expected-bucket-name';
     await acceptVisualChanges(

--- a/app/backend/test/findReasonToPreventBaseImageUpdate.test.ts
+++ b/app/backend/test/findReasonToPreventBaseImageUpdate.test.ts
@@ -40,7 +40,8 @@ describe('findReasonToPreventVisualChangeAcceptance', () => {
     const result = await findReasonToPreventVisualChangeAcceptance(
       'github-owner',
       'github-repo',
-      'sha'
+      'sha',
+      true
     );
     expect(result).toBeUndefined();
   });
@@ -73,7 +74,8 @@ describe('findReasonToPreventVisualChangeAcceptance', () => {
     const result = await findReasonToPreventVisualChangeAcceptance(
       'github-owner',
       'github-repo',
-      'sha'
+      'sha',
+      true
     );
     expect(result).toBe(
       'All other PR checks must pass before updating base images! These checks have not passed on your PR: other tests, even more tests'
@@ -103,7 +105,8 @@ describe('findReasonToPreventVisualChangeAcceptance', () => {
     const result = await findReasonToPreventVisualChangeAcceptance(
       'github-owner',
       'github-repo',
-      'sha'
+      'sha',
+      true
     );
     expect(result).toBe(
       'All other PR checks must pass before updating base images! These checks have not passed on your PR: other tests'
@@ -133,7 +136,8 @@ describe('findReasonToPreventVisualChangeAcceptance', () => {
     const result = await findReasonToPreventVisualChangeAcceptance(
       'github-owner',
       'github-repo',
-      'sha'
+      'sha',
+      true
     );
     expect(result).toBeUndefined();
   });
@@ -161,7 +165,8 @@ describe('findReasonToPreventVisualChangeAcceptance', () => {
     const result = await findReasonToPreventVisualChangeAcceptance(
       'github-owner',
       'github-repo',
-      'sha'
+      'sha',
+      true
     );
     expect(result).toBe(
       'All other PR checks must pass before updating base images! These checks have not passed on your PR: unit tests'
@@ -187,7 +192,8 @@ describe('findReasonToPreventVisualChangeAcceptance', () => {
     const result = await findReasonToPreventVisualChangeAcceptance(
       'github-owner',
       'github-repo',
-      'sha'
+      'sha',
+      true
     );
     expect(result).toBe(
       'At least one visual test job failed to take a screenshot. All jobs must take a screenshot before reviewing and updating base images!'


### PR DESCRIPTION
## Summary

- When accepting visual changes without updating base images (`useBaseImages: false`), the gate that blocks on failing non-visual PR checks no longer applies
- The non-visual checks gate exists to protect base image integrity — if base images aren't being modified, there's no reason to enforce it
- Added a test case to explicitly cover the scenario where non-visual checks have failed but `useBaseImages` is false

## Changes

- Accepting visual changes with `useBaseImages: false` is no longer blocked by failing or pending non-visual PR checks
- The non-visual checks gate is still enforced when `useBaseImages: true`

## Test plan

- [ ] Run backend tests: `bun test app/backend/test`
- [ ] Verify that a PR with failing non-visual checks can have visual changes accepted when `useBaseImages` is false
- [ ] Verify that a PR with failing non-visual checks is still blocked from accepting when `useBaseImages` is true

---
Generated with [Claude Code](https://claude.com/claude-code)