### PR TITLE
fix(ci): use npm pkg set to write version to package.json before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Publish
         working-directory: comparadise-utils
         run: |
-          pnpm version $NEW_VERSION --no-workspaces-update
+          npm pkg set version=$NEW_VERSION
           pnpm publish --no-git-checks
 
   publish-tags:


### PR DESCRIPTION
## Summary

- The publish workflow was calling `pnpm version` with `--workspaces-update false` to bump the version in `comparadise-utils/package.json` before publishing to npm
- pnpm's `version` subcommand does not support this flag (it's npm-only), causing the publish job to fail
- `npm pkg set` is a direct JSON write to `package.json` with no git commits, no workspace traversal, and no pnpm involvement — the right tool for this job

## Changes

- Replaced `pnpm version $NEW_VERSION --workspaces-update false` with `npm pkg set version=$NEW_VERSION` in the publish workflow

## Test plan

- [ ] Trigger a release and confirm the `publish-comparadise-utils` job completes without error
- [ ] Confirm the published package on npm has the correct version

---
Generated with [Claude Code](https://claude.com/claude-code)