### PR TITLE
chore(eslint): ban non-null assertion operators in source files

### DIFF
--- a/app/client.tsx
+++ b/app/client.tsx
@@ -5,7 +5,9 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const root = createRoot(document.getElementById('root')!);
+  const rootElement = document.getElementById('root');
+  if (!rootElement) throw new Error('Root element not found');
+  const root = createRoot(rootElement);
   root.render(
     <BrowserRouter>
       <App />

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,13 @@ export default [
     }
   },
   {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/*.test.ts', '**/*.test.tsx'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'error'
+    }
+  },
+  {
     files: ['app/**/*.ts', 'app/**/*.tsx'],
     ignores: ['app/build.ts'],
     rules: {


### PR DESCRIPTION
## Summary

- Adds the `@typescript-eslint/no-non-null-assertion` ESLint rule as an error for all TypeScript source files, excluding test files
- Prevents future use of `!` non-null assertions, enforcing explicit null checks instead
- Fixes the existing violation in the app entry point by replacing the assertion with a proper null guard that throws a descriptive error